### PR TITLE
Upgrade to async-http-client-2, receive with reactive streams.

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -52,7 +52,7 @@ object AsyncHttpClient {
 
       override def onStream(publisher: Publisher[HttpResponseBodyPart]): State = {
         publisher.subscribe(new Subscriber[HttpResponseBodyPart] {
-          var subscription: Option[Subscription] = _
+          var subscription: Option[Subscription] = None
 
           override def onError(t: Throwable): Unit = {
             subscription = None
@@ -70,7 +70,6 @@ object AsyncHttpClient {
           }
 
           override def onNext(t: HttpResponseBodyPart): Unit = {
-            println("ON NEXT")
             subscription foreach { s =>
               state match {
                 case State.CONTINUE =>

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -44,7 +44,7 @@ object Http4sBuild extends Build {
   }
 
   lazy val alpnBoot            = "org.mortbay.jetty.alpn"    % "alpn-boot"               % "8.1.4.v20150727"
-  lazy val asyncHttp           = "com.ning"                  % "async-http-client"       % "1.9.31"
+  lazy val asyncHttp           = "org.asynchttpclient"       % "async-http-client"       % "2.0.0-RC7"
   lazy val blaze               = "org.http4s"               %% "blaze-http"              % "0.11.0-SNAPSHOT"
   lazy val circeJawn           = "io.circe"                 %% "circe-jawn"              % "0.2.0"
   lazy val gatlingTest         = "io.gatling"                % "gatling-test-framework"  % "2.1.6"


### PR DESCRIPTION
This demonstrates my comment about reactive streams on http4s/http4s#503.  With this, we are able to tell the async-http-client to back off instead of pushing into a queue that's already full.