### PR TITLE
Implement queue subscriber against Reactive Streams TCK.

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/QueueSubscriber.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/QueueSubscriber.scala
@@ -1,0 +1,51 @@
+package org.http4s.client.asynchttpclient
+
+import scalaz.concurrent.Task
+import scalaz.stream.async.boundedQueue
+import scalaz.stream.Process
+import scalaz.stream.Process.repeatEval
+import org.log4s.getLogger
+
+class QueueSubscriber[A](bufferSize: Int = 8) extends UnicastSubscriber[A] {
+  private[this] val log = getLogger
+
+  private val queue =
+    boundedQueue[A](bufferSize)
+
+  private val refillProcess =
+    repeatEval {
+      Task.delay {
+        log.trace("Requesting another element")
+        request(1)
+      }
+    }
+
+  final val process: Process[Task, A] =
+    (refillProcess zipWith queue.dequeue)((_, a) => a)
+
+  def whenNext(element: A): Boolean = {
+    queue.enqueueOne(element).run
+    true
+  }
+
+  def closeQueue(): Unit = {
+    log.debug("Closing queue subscriber")
+    queue.close.run
+  }
+
+  def killQueue(): Unit = {
+    log.debug("Killing queue subscriber")
+    queue.kill.run
+  }
+
+  override def onComplete(): Unit = {
+    log.debug(s"Completed queue subscriber")
+    super.onComplete()
+    closeQueue()
+  }
+
+  override def onError(t: Throwable): Unit = {
+    super.onError(t)
+    queue.fail(t).run
+  }
+}

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/UnicastSubscriber.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/UnicastSubscriber.scala
@@ -1,0 +1,118 @@
+/*
+ * Adapted from https://github.com/reactive-streams/reactive-streams-jvm/blob/v1.0.0/examples/src/main/java/org/reactivestreams/example/unicast/SyncSubscriber.java
+ */
+package org.http4s.client.asynchttpclient
+
+import org.reactivestreams.{Subscription, Subscriber}
+import org.log4s.getLogger
+
+abstract class UnicastSubscriber[A](bufferSize: Int = 8) extends Subscriber[A] {
+  private[this] val logger = getLogger
+
+  private[this] var subscription: Subscription = _ // Obeying rule 3.1, we make this private!
+  private[this] var done: Boolean = false
+
+  override def onSubscribe(s: Subscription): Unit = {
+    // Rule 2.13
+    if (s == null) throw null
+
+    if (subscription != null) { // If someone has made a mistake and added this Subscriber multiple times, let's handle it gracefully
+      logger.error(s"This is a unicast subscriber. Canceling second subscription $s")
+      try s.cancel() // Cancel the additional subscription
+      catch {
+        case t: Throwable =>
+          // Subscription.cancel is not allowed to throw an exception, according to rule 3.15
+          logger.error(t)(s"$s violated the Reactive Streams rule 3.15 by throwing an exception from cancel.")
+      }
+    }
+    else {
+      logger.info(s"Subscriber $this starting subscription to $s")
+      // We have to assign it locally before we use it, if we want to be a synchronous `Subscriber`
+      // Because according to rule 3.10, the Subscription is allowed to call `onNext` synchronously from within `request`
+      subscription = s
+      request(1)
+    }
+  }
+
+  override def onNext(element: A): Unit = {
+    logger.debug(s"Received element $element")
+    if (subscription == null) { // Technically this check is not needed, since we are expecting Publishers to conform to the spec
+      logger.error(new IllegalStateException)("Publisher violated the Reactive Streams rule 1.09 signalling onNext prior to onSubscribe.")
+    } else {
+      // As per rule 2.13, we need to throw a `java.lang.NullPointerException` if the `element` is `null`
+      if (element == null) throw null
+      if (!done) { // If we aren't already done
+        try {
+          if (!whenNext(element))
+            finish()
+        }
+        catch {
+          case t: Throwable =>
+            finish()
+            try onError(t)
+            catch {
+              case t2: Throwable =>
+                // Subscriber.onError is not allowed to throw an exception, according to rule 2.13
+                logger.error(t2)(s"$this violated the Reactive Streams rule 2.13 by throwing an exception from onError.")
+            }
+        }
+      }
+      else {
+        logger.info(s"We were already done before we received $element. Not handed to whenNext.")
+      }
+    }
+  }
+
+  // Showcases a convenience method to idempotently marking the Subscriber as "done", so we don't want to process more elements
+  // here for we also need to cancel our `Subscription`.
+  private def finish(): Unit = {
+    logger.info(s"Subscriber $this closing subscription to $subscription")
+    //On this line we could add a guard against `!done`, but since rule 3.7 says that `Subscription.cancel()` is idempotent, we don't need to.
+    done = true // If we `whenNext` throws an exception, let's consider ourselves done (not accepting more elements)
+    try subscription.cancel() // Cancel the subscription
+    catch {
+      case t: Throwable =>
+        //Subscription.cancel is not allowed to throw an exception, according to rule 3.15
+        logger.error(t)(s"$subscription violated the Reactive Streams rule 3.15 by throwing an exception from cancel.")
+    }
+  }
+
+  // This method is left as an exercise to the reader/extension point
+  // Returns whether more elements are desired or not, and if no more elements are desired
+  protected def whenNext(element: A): Boolean
+
+  protected def request(n: Int): Unit = {
+    try {
+      logger.debug(s"Triggering request of $n elements to $subscription")
+      // If we want elements, according to rule 2.1 we need to call `request`
+      // And, according to rule 3.2 we are allowed to call this synchronously from within the `onSubscribe` method
+      subscription.request(n)
+    }
+    catch {
+      case t: Throwable =>
+        // Subscription.request is not allowed to throw according to rule 3.16
+        logger.error(t)(s"$subscription violated the Reactive Streams rule 3.16 by throwing an exception from request.")
+    }
+  }
+
+  override def onError(t: Throwable): Unit = {
+    if (subscription == null) { // Technically this check is not needed, since we are expecting Publishers to conform to the spec
+      logger.error("Publisher violated the Reactive Streams rule 1.09 signalling onError prior to onSubscribe.")
+    }
+    else {
+      // As per rule 2.13, we need to throw a `java.lang.NullPointerException` if the `Throwable` is `null`
+      if (t == null) throw null
+      // Here we are not allowed to call any methods on the `Subscription` or the `Publisher`, as per rule 2.3
+      // And anyway, the `Subscription` is considered to be cancelled if this method gets called, as per rule 2.4
+    }
+  }
+
+  override def onComplete(): Unit = {
+    if (subscription == null) { // Technically this check is not needed, since we are expecting Publishers to conform to the spec
+      logger.error("Publisher violated the Reactive Streams rule 1.09 signalling onComplete prior to onSubscribe.")
+    } else {
+      // Here we are not allowed to call any methods on the `Subscription` or the `Publisher`, as per rule 2.3
+      // And anyway, the `Subscription` is considered to be cancelled if this method gets called, as per rule 2.4
+    }
+  }
+}

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/QueueSubscriberTest.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/QueueSubscriberTest.scala
@@ -1,0 +1,70 @@
+package org.http4s.client.asynchttpclient
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.reactivestreams.{Subscription, Publisher, Subscriber}
+import org.reactivestreams.tck.SubscriberWhiteboxVerification.WhiteboxSubscriberProbe
+import org.reactivestreams.tck.{SubscriberWhiteboxVerification, TestEnvironment}
+import org.testng.annotations._
+import org.testng.Assert._
+
+import scalaz.-\/
+
+class QueueSubscriberTest extends SubscriberWhiteboxVerification[Integer](new TestEnvironment) {
+  private lazy val counter = new AtomicInteger
+
+  override def createSubscriber(theProbe: WhiteboxSubscriberProbe[Integer]): Subscriber[Integer] = {
+    val subscriber = new QueueSubscriber[Integer](2) with WhiteboxSubscriber[Integer] {
+      override def probe: WhiteboxSubscriberProbe[Integer] = theProbe
+    }
+    subscriber
+  }
+
+  def createSubscriber(): QueueSubscriber[Integer] =
+    new QueueSubscriber[Integer](1)
+
+  override def createElement(element: Int): Integer =
+    counter.getAndIncrement
+
+  @Test
+  def emitsToProcess() = {
+    val publisher = createHelperPublisher(10)
+    val subscriber = createSubscriber()
+    publisher.subscribe(subscriber)
+    assertEquals(subscriber.process.runLog.run.size, 10)
+  }
+
+  @Test
+  def failsProcessOnError() = {
+    object SadTrombone extends Exception
+    val publisher = new Publisher[Integer] {
+      override def subscribe(s: Subscriber[_ >: Integer]): Unit = {
+        s.onSubscribe(new Subscription {
+          override def cancel(): Unit = {}
+          override def request(n: Long): Unit = {}
+        })
+        s.onError(SadTrombone)
+      }
+    }
+    val subscriber = createSubscriber()
+    publisher.subscribe(subscriber)
+    assertEquals(subscriber.process.runLog.attemptRun, -\/(SadTrombone))
+  }
+
+  @Test
+  def closesQueueOnComplete() = {
+    object SadTrombone extends Exception
+    val publisher = new Publisher[Integer] {
+      override def subscribe(s: Subscriber[_ >: Integer]): Unit = {
+        s.onSubscribe(new Subscription {
+          override def cancel(): Unit = {}
+          override def request(n: Long): Unit = {}
+        })
+        s.onComplete()
+      }
+    }
+    val subscriber = createSubscriber()
+    publisher.subscribe(subscriber)
+    assertEquals(subscriber.process.runLog.run, Vector.empty)
+  }
+}

--- a/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/WhiteboxSubscriber.scala
+++ b/async-http-client/src/test/scala/org/http4s/client/asynchttpclient/WhiteboxSubscriber.scala
@@ -1,0 +1,37 @@
+package org.http4s.client.asynchttpclient
+
+import org.reactivestreams.tck.SubscriberWhiteboxVerification.{SubscriberPuppet, WhiteboxSubscriberProbe}
+import org.reactivestreams.{Subscription, Subscriber}
+
+/** Stackable trait to ease creating whitebox subscriber tests. */
+trait WhiteboxSubscriber[A] extends Subscriber[A] {
+  def probe: WhiteboxSubscriberProbe[A]
+
+  abstract override def onError(t: Throwable): Unit = {
+    super.onError(t)
+    probe.registerOnError(t)
+  }
+
+  abstract override def onSubscribe(s: Subscription): Unit = {
+    super.onSubscribe(s)
+    probe.registerOnSubscribe(new SubscriberPuppet {
+      override def triggerRequest(elements: Long): Unit = {
+        s.request(elements)
+      }
+
+      override def signalCancel(): Unit = {
+        s.cancel()
+      }
+    })
+  }
+
+  abstract override def onComplete(): Unit = {
+    super.onComplete()
+    probe.registerOnComplete()
+  }
+
+  abstract override def onNext(a: A): Unit = {
+    super.onNext(a)
+    probe.registerOnNext(a)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,10 @@ lazy val blazeClient = libraryProject("blaze-client")
 lazy val asyncHttpClient = libraryProject("async-http-client")
   .settings(
     description := "async http client implementation for http4s clients",
-    libraryDependencies += asyncHttp
+    libraryDependencies ++= Seq(
+      asyncHttp,
+      reactiveStreamsTck % "test"
+    )
   )
   .dependsOn(core % "compile;test->test", client % "compile;test->test")
 

--- a/project/Http4sBuild.scala
+++ b/project/Http4sBuild.scala
@@ -69,6 +69,7 @@ object Http4sBuild extends Build {
   lazy val metricsServlets     = "io.dropwizard.metrics"     % "metrics-servlets"        % metricsCore.revision
   lazy val metricsJson         = "io.dropwizard.metrics"     % "metrics-json"            % metricsCore.revision
   lazy val parboiled           = "org.parboiled"            %% "parboiled"               % "2.1.0"
+  lazy val reactiveStreamsTck  = "org.reactivestreams"       % "reactive-streams-tck"    % "1.0.0"
   def scalaReflect(sv: String) = "org.scala-lang"            % "scala-reflect"           % sv
   lazy val scalameter          = "com.storm-enroute"        %% "scalameter"              % "0.6"
   lazy val scalaXml            = "org.scala-lang.modules"   %% "scala-xml"               % "1.0.5"


### PR DESCRIPTION
UnicastSubscriber is based on the Reactive Streams example, and
catches the various rules we missed the first time around.  A
big difference is that we expose a method for requesting,
instead of requesting every time we receive (thus blocking
the producer when inserting into a bounded queue with a slow
consumer).

QueueSubscriber extends that to generically adapt a Publisher
to a Process.

The client extends the new QueueSubscriber to do most of the
dirty work.